### PR TITLE
Fix Duplicate Word in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ SELECT '5'::INTEGER; -- Using :: syntax.
 ```
 
 ### Anti-joins are your friend
-Anti-joins are incredible useful, mostly (in my experience) for when when you only want to return rows/values from one table that aren't present in another table.
+Anti-joins are incredible useful, mostly (in my experience) for when you only want to return rows/values from one table that aren't present in another table.
 - You could instead use a subquery although conventional wisdom dictates that
 anti-joins are faster.
 - `EXCEPT` is an interesting operator for removing rows from one table which appear in another query table but I suggest you read up on it further before using it.


### PR DESCRIPTION
This pull request removes a duplicated "when" in the "Useful features" > "Anti-joins are your friend" section of the README.md file, enhancing readability and clarity.

    Original: "when when"
    Fixed: "when"

Please review the change and let me know if further adjustments are needed. Thank you!