### PR TITLE
Refactor SQL query to use table alias in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ AND series_id NOT IN (SELECT DISTINCT SERIES_ID FROM archive) -- Be mindful of N
 -- Correlated subquery.
 SELECT 
 *
-FROM video_content
+FROM video_content vc
 WHERE 1=1
 AND NOT EXISTS (
         SELECT 1


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file. The change involves updating the SQL query to use an alias for the `video_content` table.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L200-R200): Updated the SQL query to use an alias `vc` for the `video_content` table.