### PR TITLE
Fix typos and improve readability in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please note that some of these tips might not be relevant for all RDBMs. For exa
 ## Formatting/readability
 ### Use a leading comma to separate fields
 
-Use a leading comma to seperate fields in the `SELECT` clause rather than a trailing comma.
+Use a leading comma to separate fields in the `SELECT` clause rather than a trailing comma.
 
 - Clearly defines that this is a new column vs code that's wrapped to multiple lines.
 
@@ -105,7 +105,7 @@ FROM timeslot_data
 
 ### Consider CTEs when writing complex queries
 For longer than I'd care to admit I would nest inline views, which would lead to
-queries that were hard to understand, particularly if revisted after a few weeks.
+queries that were hard to understand, particularly if revisited after a few weeks.
 
 If you find yourself nesting inline views more than 2 or 3 levels deep, 
 consider using common table expressions, which can help you keep your code more organised and readable.


### PR DESCRIPTION
This pull request includes minor corrections to spelling errors in the `README.md` file to improve readability and accuracy.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R38): Corrected the spelling of "seperate" to "separate" in the section about using a leading comma in the `SELECT` clause.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L108-R108): Corrected the spelling of "revisted" to "revisited" in the section about using common table expressions (CTEs) for complex queries.